### PR TITLE
Add Japanese translations

### DIFF
--- a/src/flow-debugger.html
+++ b/src/flow-debugger.html
@@ -625,14 +625,19 @@
                     }
 
                     var tools = $('<span class="red-ui-flow-debugger-msg-tools button-group"></span>').appendTo(topRow);
-                    var stepItem = $('<button class="red-ui-button red-ui-button-small"><i class="fa fa-step-forward"></i></button>').appendTo(tools).on("click", function(evt) {
+                    var stepItem = $('<button class="red-ui-button red-ui-button-small"><i class="fa fa-step-forward"></i></button>').appendTo(tools);
+                    var stepMessage = RED.popover.tooltip(stepItem, RED._("node-red-debugger/flow-debugger:label.stepMessage"));
+                    stepItem.on("click", function(evt) {
                         evt.preventDefault();
                         evt.stopPropagation();
                         postCommand("step",{message: item.id})
                         messageList.editableList("removeItem",item);
+                        stepMessage.close();
                     });
 
-                    var deleteItem = $('<button class="red-ui-button red-ui-button-small"><i class="fa fa-trash"></i></button>').appendTo(tools).on("click", function(evt) {
+                    var deleteItem = $('<button class="red-ui-button red-ui-button-small"><i class="fa fa-trash"></i></button>').appendTo(tools);
+                    var deleteMessage = RED.popover.tooltip(deleteItem, RED._("node-red-debugger/flow-debugger:label.deleteMessage"));
+                    deleteItem .on("click", function(evt) {
                         evt.preventDefault();
                         evt.stopPropagation();
                         $.ajax({
@@ -642,6 +647,7 @@
                                 console.log(jqXHR,textStatus,errorThrown);
                             }
                         });
+                        deleteMessage.close();
                     });
 
                     if (item.msg) {

--- a/src/locales/ja/flow-debugger.json
+++ b/src/locales/ja/flow-debugger.json
@@ -3,7 +3,7 @@
         "debugger": "フローデバッガ",
         "debuggerShort": "デバッガ",
         "breakpoints": "ブレイクポイント",
-        "messages":"メッセージ",
+        "messages": "メッセージ",
         "output": "出力",
         "input": "入力",
         "paused": "フローを停止しました",
@@ -11,6 +11,17 @@
         "step": "フローをステップ実行",
         "pause": "フローを停止",
         "deleteMessage": "メッセージを削除",
-        "stepMessage": "メッセージをステップ実行"
+        "stepMessage": "メッセージをステップ実行",
+        "filter": {
+            "label": "メッセージの絞り込み",
+            "all": "全てのノード",
+            "flow": "現在のフロー"
+        },
+        "settings": "デバッガオプション",
+        "breakpointAction": {
+            "label": "ブレイクポイントの動作",
+            "pause-all": "全てのノードを停止",
+            "pause-bp": "ブレイクポイントで停止"
+        }
     }
 }

--- a/src/locales/ja/flow-debugger.json
+++ b/src/locales/ja/flow-debugger.json
@@ -1,0 +1,16 @@
+{
+    "label": {
+        "debugger": "フローデバッガ",
+        "debuggerShort": "デバッガ",
+        "breakpoints": "ブレイクポイント",
+        "messages":"メッセージ",
+        "output": "出力",
+        "input": "入力",
+        "paused": "フローを停止しました",
+        "resume": "フローを再開",
+        "step": "フローをステップ実行",
+        "pause": "フローを停止",
+        "deleteMessage": "メッセージを削除",
+        "stepMessage": "メッセージをステップ実行"
+    }
+}


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I added Japanese translations for the flow debugger. Because the tooltips of `stepMessage` and `deleteMessage` were still visible after clicking the button to delete item, I added handling to be invisible using `stepMessage.close()` and `deleteMessage.close()` respectively.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.